### PR TITLE
Removing mis-parsed command docs

### DIFF
--- a/src/darts.coffee
+++ b/src/darts.coffee
@@ -8,8 +8,7 @@
 #   None
 #
 # Commands:
-#   hubot shoot target (in the legs/head/body) - Fire's a foam dart at the target
-#    Optionalls attempts to aim for a specific area of the body.
+#   hubot shoot target (in the legs/head/body) - Fires a foam dart at the target
 #
 # Notes:
 #   None


### PR DESCRIPTION
Hubot treats this additional line as another line of documentation, so this second line is shown separately in the help, causing confusion.
